### PR TITLE
feat: update rust edition to 2024 and change asm! to naked_asm!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,63 +4,65 @@ version = 4
 
 [[package]]
 name = "aclint"
-version = "0.0.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a01ba40421eca6c4f1afcedd8465fba6d9e5ef8e0e13060d0141e4cded4ab4a"
+checksum = "8cc30f3f60fd3106787fa9b540e64372dd4793813c400ba12d113506e94dcb8c"
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bench-kernel"
@@ -68,7 +70,7 @@ version = "0.0.1"
 dependencies = [
  "rcore-console",
  "riscv 0.10.1",
- "sbi-rt",
+ "sbi-rt 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uart16550",
 ]
 
@@ -79,10 +81,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
-name = "clap"
-version = "4.5.0"
+name = "bitflags"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "clap"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -90,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -102,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -114,21 +122,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "dtb-walker"
@@ -154,28 +162,34 @@ checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "fast-trap"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbe69badc2e0dc98ad2787648fa140b5772d24b49e9a6b180a67e1348f7544c"
+checksum = "46da95e6fcc7619a12d05594693e48591c0b574aef6fe5d7a7e765e6763a2cb2"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hsm-cell"
 version = "0.1.0"
 dependencies = [
- "sbi-spec",
+ "sbi-spec 0.0.7",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -183,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "nb"
@@ -204,9 +218,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "os-xtask-utils"
@@ -218,19 +232,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.88"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -267,6 +287,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "riscv"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
+dependencies = [
+ "critical-section",
+ "embedded-hal 1.0.0",
+ "paste",
+ "riscv-pac",
+]
+
+[[package]]
+name = "riscv-pac"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
+
+[[package]]
 name = "rustsbi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +312,7 @@ checksum = "44c13763120794ed11d64bac885fb31d384ae385c3287b0697711b97affbf8ab"
 dependencies = [
  "riscv 0.11.1",
  "rustsbi-macros",
- "sbi-spec",
+ "sbi-spec 0.0.7",
 ]
 
 [[package]]
@@ -299,7 +337,7 @@ dependencies = [
  "rcore-console",
  "riscv 0.10.1",
  "rustsbi",
- "sbi-spec",
+ "sbi-spec 0.0.7",
  "sifive-test-device",
  "spin",
  "uart16550",
@@ -311,7 +349,15 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
 dependencies = [
- "sbi-spec",
+ "sbi-spec 0.0.7",
+]
+
+[[package]]
+name = "sbi-rt"
+version = "0.0.3"
+source = "git+https://github.com/rustsbi/rustsbi?rev=c53f4dd68e99adeb5030d3ff1f1c78ca413754ab#c53f4dd68e99adeb5030d3ff1f1c78ca413754ab"
+dependencies = [
+ "sbi-spec 0.0.8",
 ]
 
 [[package]]
@@ -321,15 +367,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
+name = "sbi-spec"
+version = "0.0.8"
+source = "git+https://github.com/rustsbi/rustsbi?rev=c53f4dd68e99adeb5030d3ff1f1c78ca413754ab#c53f4dd68e99adeb5030d3ff1f1c78ca413754ab"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "sbi-testing"
 version = "0.0.3-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135c0f1ce07ede77a7e1c3daff35d20d37b54fd1037ac02ab9595c231518531e"
+source = "git+https://github.com/rustsbi/rustsbi?rev=c53f4dd68e99adeb5030d3ff1f1c78ca413754ab#c53f4dd68e99adeb5030d3ff1f1c78ca413754ab"
 dependencies = [
  "log",
- "riscv 0.11.1",
- "sbi-rt",
- "sbi-spec",
+ "riscv 0.12.1",
+ "sbi-rt 0.0.3 (git+https://github.com/rustsbi/rustsbi?rev=c53f4dd68e99adeb5030d3ff1f1c78ca413754ab)",
+ "sbi-spec 0.0.8",
 ]
 
 [[package]]
@@ -355,15 +408,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -391,15 +444,15 @@ checksum = "939f6f9ccad815fe3efca8fd06f2ec1620c0387fb1bca2b231b61ce710bffb9b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "void"
@@ -409,22 +462,23 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -433,45 +487,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xtask"

--- a/bench-kernel/Cargo.toml
+++ b/bench-kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench-kernel"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 publish = false
 

--- a/hsm-cell/Cargo.toml
+++ b/hsm-cell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hsm-cell"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rustsbi-qemu/Cargo.toml
+++ b/rustsbi-qemu/Cargo.toml
@@ -12,7 +12,7 @@ license = "MulanPSL-2.0 OR MIT"
 readme = "README.md"
 keywords = ["riscv", "sbi", "rustsbi"]
 categories = ["os", "embedded", "hardware-support", "no-std"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,10 +22,10 @@ sbi-spec = { version = "0.0.7", features = ["legacy"] }
 riscv = "0.10.1"
 spin = "0.9"
 rcore-console = "0.0.0"
-aclint = "0.0.0"
+aclint = "0.1.0"
 sifive-test-device = "0.0.0"
 dtb-walker = "=0.2.0-alpha.3"
 uart16550 = "0.0.1"
 
 hsm-cell = { path = "../hsm-cell" }
-fast-trap = { version = "=0.0.1", features = ["riscv-m"] }
+fast-trap = { version = "=0.1.0", features = ["riscv-m"] }

--- a/rustsbi-qemu/src/trap_vec.rs
+++ b/rustsbi-qemu/src/trap_vec.rs
@@ -1,6 +1,6 @@
 use crate::clint::CLINT;
 use aclint::SifiveClint as Clint;
-use core::arch::asm;
+use core::arch::naked_asm;
 use fast_trap::trap_entry;
 
 /// 中断向量表
@@ -10,28 +10,29 @@ use fast_trap::trap_entry;
 /// 裸函数。
 #[naked]
 pub(crate) unsafe extern "C" fn trap_vec() {
-    asm!(
-        ".align 2",
-        ".option push",
-        ".option norvc",
-        "j {default}", // exception
-        "j {default}", // supervisor software
-        "j {default}", // reserved
-        "j {msoft} ",  // machine    software
-        "j {default}", // reserved
-        "j {default}", // supervisor timer
-        "j {default}", // reserved
-        "j {mtimer}",  // machine    timer
-        "j {default}", // reserved
-        "j {default}", // supervisor external
-        "j {default}", // reserved
-        "j {default}", // machine    external
-        ".option pop",
-        default = sym trap_entry,
-        mtimer  = sym mtimer,
-        msoft   = sym msoft,
-        options(noreturn)
-    )
+    unsafe{
+        naked_asm!(
+            ".align 2",
+            ".option push",
+            ".option norvc",
+            "j {default}", // exception
+            "j {default}", // supervisor software
+            "j {default}", // reserved
+            "j {msoft} ",  // machine    software
+            "j {default}", // reserved
+            "j {default}", // supervisor timer
+            "j {default}", // reserved
+            "j {mtimer}",  // machine    timer
+            "j {default}", // reserved
+            "j {default}", // supervisor external
+            "j {default}", // reserved
+            "j {default}", // machine    external
+            ".option pop",
+            default = sym trap_entry,
+            mtimer  = sym mtimer,
+            msoft   = sym msoft,
+        )
+    }
 }
 
 /// machine timer 中断代理
@@ -41,48 +42,50 @@ pub(crate) unsafe extern "C" fn trap_vec() {
 /// 裸函数。
 #[naked]
 unsafe extern "C" fn mtimer() {
-    asm!(
-        // 换栈：
-        // sp      : M sp
-        // mscratch: S sp
-        "   csrrw sp, mscratch, sp",
-        // 保护
-        "   addi  sp, sp, -4*8
-            sd    ra, 0*8(sp)
-            sd    a0, 1*8(sp)
-            sd    a1, 2*8(sp)
-            sd    a2, 3*8(sp)
-        ",
-        // 清除 mtimecmp
-        "   la    a0, {clint_ptr}
-            ld    a0, (a0)
-            csrr  a1, mhartid
-            addi  a2, zero, -1
-            call  {set_mtimecmp}
-        ",
-        // 设置 stip
-        "   li    a0, {mip_stip}
-            csrrs zero, mip, a0
-        ",
-        // 恢复
-        "   ld    ra, 0*8(sp)
-            ld    a0, 1*8(sp)
-            ld    a1, 2*8(sp)
-            ld    a2, 3*8(sp)
-            addi  sp, sp,  4*8
-        ",
-        // 换栈：
-        // sp      : S sp
-        // mscratch: M sp
-        "   csrrw sp, mscratch, sp",
-        // 返回
-        "   mret",
-        mip_stip     = const 1 << 5,
-        clint_ptr    =   sym CLINT,
-        //                   Clint::write_mtimecmp_naked(&self, hart_idx, val)
-        set_mtimecmp =   sym Clint::write_mtimecmp_naked,
-        options(noreturn)
-    )
+    unsafe{
+        naked_asm!(
+            // 换栈：
+            // sp      : M sp
+            // mscratch: S sp
+            "   csrrw sp, mscratch, sp",
+            // 保护
+            "   addi  sp, sp, -4*8
+                sd    ra, 0*8(sp)
+                sd    a0, 1*8(sp)
+                sd    a1, 2*8(sp)
+                sd    a2, 3*8(sp)
+            ",
+            // 清除 mtimecmp
+            "   la    a0, {clint_ptr}
+                ld    a0, (a0)
+                csrr  a1, mhartid
+                addi  a2, zero, -1
+                call  {set_mtimecmp}
+            ",
+            // 设置 stip
+            "   li    a0, {mip_stip}
+                csrrs zero, mip, a0
+            ",
+            // 恢复
+            "   ld    ra, 0*8(sp)
+                ld    a0, 1*8(sp)
+                ld    a1, 2*8(sp)
+                ld    a2, 3*8(sp)
+                addi  sp, sp,  4*8
+            ",
+            // 换栈：
+            // sp      : S sp
+            // mscratch: M sp
+            "   csrrw sp, mscratch, sp",
+            // 返回
+            "   mret",
+            mip_stip     = const 1 << 5,
+            clint_ptr    =   sym CLINT,
+            //                   Clint::write_mtimecmp_naked(&self, hart_idx, val)
+            set_mtimecmp =   sym Clint::write_mtimecmp_naked,
+
+        )
+    }
 }
 
 /// machine soft 中断代理
@@ -92,39 +95,41 @@ unsafe extern "C" fn mtimer() {
 /// 裸函数。
 #[naked]
 unsafe extern "C" fn msoft() {
-    asm!(
-        // 换栈：
-        // sp      : M sp
-        // mscratch: S sp
-        "   csrrw sp, mscratch, sp",
-        // 保护
-        "   addi sp, sp, -3*8
-            sd   ra, 0*8(sp)
-            sd   a0, 1*8(sp)
-            sd   a1, 2*8(sp)
-        ",
-        // 清除 msip 设置 ssip
-        "   la   a0, {clint_ptr}
-            ld   a0, (a0)
-            csrr a1, mhartid
-            call {clear_msip}
-            csrrsi zero, mip, 1 << 1
-        ",
-        // 恢复
-        "   ld   ra, 0*8(sp)
-            ld   a0, 1*8(sp)
-            ld   a1, 2*8(sp)
-            addi sp, sp,  3*8
-        ",
-        // 换栈：
-        // sp      : S sp
-        // mscratch: M sp
-        "   csrrw sp, mscratch, sp",
-        // 返回
-        "   mret",
-        clint_ptr  = sym CLINT,
-        //               Clint::clear_msip_naked(&self, hart_idx)
-        clear_msip = sym Clint::clear_msip_naked,
-        options(noreturn)
-    )
+    unsafe{
+        naked_asm!(
+            // 换栈：
+            // sp      : M sp
+            // mscratch: S sp
+            "   csrrw sp, mscratch, sp",
+            // 保护
+            "   addi sp, sp, -3*8
+                sd   ra, 0*8(sp)
+                sd   a0, 1*8(sp)
+                sd   a1, 2*8(sp)
+            ",
+            // 清除 msip 设置 ssip
+            "   la   a0, {clint_ptr}
+                ld   a0, (a0)
+                csrr a1, mhartid
+                call {clear_msip}
+                csrrsi zero, mip, 1 << 1
+            ",
+            // 恢复
+            "   ld   ra, 0*8(sp)
+                ld   a0, 1*8(sp)
+                ld   a1, 2*8(sp)
+                addi sp, sp,  3*8
+            ",
+            // 换栈：
+            // sp      : S sp
+            // mscratch: M sp
+            "   csrrw sp, mscratch, sp",
+            // 返回
+            "   mret",
+            clint_ptr  = sym CLINT,
+            //               Clint::clear_msip_naked(&self, hart_idx)
+            clear_msip = sym Clint::clear_msip_naked,
+
+        )
+    }
 }

--- a/test-kernel/Cargo.toml
+++ b/test-kernel/Cargo.toml
@@ -2,13 +2,13 @@
 name = "test-kernel"
 version = "0.2.0"
 authors = ["Luo Jia <me@luojia.cc>", "YdrMaster <ydrml@hotmail.com>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sbi-testing = { version = "0.0.3-alpha.2", features = ["log"] }
+sbi-testing = {  git = "https://github.com/rustsbi/rustsbi", features = ["log"],rev = "c53f4dd68e99adeb5030d3ff1f1c78ca413754ab" }
 log = "0.4"
 riscv = "0.10.1"
 spin = "0.9"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,7 +3,7 @@ name = "xtask"
 version = "0.2.0"
 authors = ["Luo Jia <me@luojia.cc>", "YdrMaster <ydrml@hotmail.com>"]
 description = "Interactive cargo runner, to build, analyze and test RustSBI-Qemu."
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pull request do the following jobs:

update rust edition to 2024 and change `asm!` to `naked_asm!`
bump `aclint` to 0.1.0
bump `fast-trap` to 0.1.0
sbi-testing: use https://github.com/rustsbi/rustsbi/commit/c53f4dd68e99adeb5030d3ff1f1c78ca413754ab