### PR TITLE
bench-kernel: replace #[naked] with #[unsafe(naked)] for stable Rust

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         base-img: [slim]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixes on usage of CLINT peripheral, thanks to @duskmoon314
 - Numerous fixes to HSM module implementation, more documents
 
+## [0.1.1] - 2025-04-22
+
+### Modified
+- Replaced #[naked] with #[unsafe(naked)] across all relevant functions.
+- Removed `#![feature(naked_functions, asm_const)]` as they are no longer needed.
+- Switched to the `naked_asm!` macro to comply with new naked function requirements.
+- Removed `options(noreturn)`, which is not allowed in `naked_asm!`.
+- Updated implementations of `put_char` and `put_str` in 
+  `impl rcore_console::Console for Console` to avoid errors caused by 
+  creating shared references to mutable statics.
+- Updated GitHub Actions YAML workflow files to replace `ubuntu-20.04` with 
+  `ubuntu-22.04` for CI compatibility.
+  
 [Unreleased]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/rustsbi/rustsbi-qemu/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   creating shared references to mutable statics.
 - Updated GitHub Actions YAML workflow files to replace `ubuntu-20.04` with 
   `ubuntu-22.04` for CI compatibility.
-  
+- Updated GitHub Actions YAML workflow files to replace `ubuntu-20.04` with 
+  `ubuntu-22.04` for CI test.
+
 [Unreleased]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/rustsbi/rustsbi-qemu/releases/tag/v0.1.0

--- a/bench-kernel/src/main.rs
+++ b/bench-kernel/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_const)]
 #![deny(warnings)]
 
 use rcore_console::log;
@@ -8,7 +7,7 @@ use riscv::register::*;
 use sbi_rt::*;
 use uart16550::Uart16550;
 
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.entry"]
 unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
@@ -17,13 +16,12 @@ unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
     #[link_section = ".bss.uninit"]
     static mut STACK: [u8; STACK_SIZE] = [0u8; STACK_SIZE];
 
-    core::arch::asm!(
+    core::arch::naked_asm!(
         "la sp,  {stack} + {stack_size}",
         "j  {main}",
         stack_size = const STACK_SIZE,
         stack      = sym   STACK,
         main       = sym   rust_main,
-        options(noreturn),
     )
 }
 
@@ -127,11 +125,17 @@ impl Uart16550Map {
 impl rcore_console::Console for Console {
     #[inline]
     fn put_char(&self, c: u8) {
-        unsafe { UART.get().write(core::slice::from_ref(&c)) };
+        unsafe {
+            let mut_ref_uart = (*(&raw mut UART)).get();
+            mut_ref_uart.write(core::slice::from_ref(&c))
+        };
     }
 
     #[inline]
     fn put_str(&self, s: &str) {
-        unsafe { UART.get().write(s.as_bytes()) };
+        unsafe {
+            let mut_ref_uart = (*(&raw mut UART)).get();
+            mut_ref_uart.write(s.as_bytes())
+        };
     }
 }


### PR DESCRIPTION
Background
The latest stable Rust compiler, following [rust-lang/rust#134213](https://github.com/rust-lang/rust/pull/134213), now requires the #[naked] attribute to be marked as unsafe using #[unsafe(naked)]. The existing use of #[naked] in the bench-kernel module causes build failures on the stable toolchain (see [workflow failure log](https://github.com/rustsbi/rustsbi/actions/runs/14575137489/job/40879573527)).

This pull request resolves that issue by updating bench-kernel for compatibility with both stable and nightly Rust.

Changes
-Replace all #[naked] attributes with #[unsafe(naked)]
-Remove #![feature(naked_functions, asm_const)] as they are no longer required
-Use the naked_asm! macro as required by the new naked function specification
-Remove options(noreturn) which is disallowed inside naked_asm!
-Refactor put_char and put_str to avoid shared references to mutable statics
-Update GitHub Actions workflows to use ubuntu-22.04 instead of ubuntu-20.04

passed cargo build and cargo clippy.