### PR TITLE
fix: making rustsbi-qemu completely runnable again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Xtask will now print error when system does not have qemu installed
 - Fix dtb parsing for qemu 7.2
 
+## [0.1.0] - 2022-02-13
+
+### Added
+
+- Adapts to RustSBI version 0.2.0
+- Implement SBI non-retentive resume procedure
+- PMP updates, use stabilized core::arch::asm! macro, thanks to @wyfcyx
+- Fixes on usage of CLINT peripheral, thanks to @duskmoon314
+- Numerous fixes to HSM module implementation, more documents
+
 ## [0.1.1] - 2022-03-23
 
 ### Added
@@ -45,15 +55,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use Rust Edition 2021
 - Modify test kernel message
 
-## [0.1.0] - 2022-02-13
+## [0.1.2] - 2025-05-16
 
-### Added
+### Modified
 
-- Adapts to RustSBI version 0.2.0
-- Implement SBI non-retentive resume procedure
-- PMP updates, use stabilized core::arch::asm! macro, thanks to @wyfcyx
-- Fixes on usage of CLINT peripheral, thanks to @duskmoon314
-- Numerous fixes to HSM module implementation, more documents
+- Bump fast-trap version to 0.1.0
+- Bump aclint version to 0.1.0
+
+### Fixed
+
+- Reorder date for CHANGELOG.md
+- Replace #[naked] with #[unsafe(naked)] across all relevant functions.
+- Remove `#![feature(naked_functions, asm_const)]` as they are no longer needed.
+- Switche to the `naked_asm!` macro to comply with new naked function requirements.
+- Remove `options(noreturn)`, which is not allowed in `naked_asm!`.
+- Fix warning `creating a mutable/shared reference to mutable static` in multiple files.
 
 [Unreleased]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/rustsbi/rustsbi-qemu/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aclint"
-version = "0.0.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a01ba40421eca6c4f1afcedd8465fba6d9e5ef8e0e13060d0141e4cded4ab4a"
+checksum = "8cc30f3f60fd3106787fa9b540e64372dd4793813c400ba12d113506e94dcb8c"
 
 [[package]]
 name = "anstream"
@@ -154,9 +154,9 @@ checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "fast-trap"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbe69badc2e0dc98ad2787648fa140b5772d24b49e9a6b180a67e1348f7544c"
+checksum = "46da95e6fcc7619a12d05594693e48591c0b574aef6fe5d7a7e765e6763a2cb2"
 
 [[package]]
 name = "heck"

--- a/rustsbi-qemu/Cargo.toml
+++ b/rustsbi-qemu/Cargo.toml
@@ -22,10 +22,10 @@ sbi-spec = { version = "0.0.7", features = ["legacy"] }
 riscv = "0.10.1"
 spin = "0.9"
 rcore-console = "0.0.0"
-aclint = "0.0.0"
+aclint = "0.1.0"
 sifive-test-device = "0.0.0"
 dtb-walker = "=0.2.0-alpha.3"
 uart16550 = "0.0.1"
 
 hsm-cell = { path = "../hsm-cell" }
-fast-trap = { version = "=0.0.1", features = ["riscv-m"] }
+fast-trap = { version = "=0.1.0", features = ["riscv-m"] }

--- a/rustsbi-qemu/src/trap_vec.rs
+++ b/rustsbi-qemu/src/trap_vec.rs
@@ -1,6 +1,6 @@
 use crate::clint::CLINT;
 use aclint::SifiveClint as Clint;
-use core::arch::asm;
+use core::arch::naked_asm;
 use fast_trap::trap_entry;
 
 /// 中断向量表
@@ -8,9 +8,9 @@ use fast_trap::trap_entry;
 /// # Safety
 ///
 /// 裸函数。
-#[naked]
+#[unsafe(naked)]
 pub(crate) unsafe extern "C" fn trap_vec() {
-    asm!(
+    naked_asm!(
         ".align 2",
         ".option push",
         ".option norvc",
@@ -30,7 +30,6 @@ pub(crate) unsafe extern "C" fn trap_vec() {
         default = sym trap_entry,
         mtimer  = sym mtimer,
         msoft   = sym msoft,
-        options(noreturn)
     )
 }
 
@@ -39,9 +38,9 @@ pub(crate) unsafe extern "C" fn trap_vec() {
 /// # Safety
 ///
 /// 裸函数。
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn mtimer() {
-    asm!(
+    naked_asm!(
         // 换栈：
         // sp      : M sp
         // mscratch: S sp
@@ -81,7 +80,6 @@ unsafe extern "C" fn mtimer() {
         clint_ptr    =   sym CLINT,
         //                   Clint::write_mtimecmp_naked(&self, hart_idx, val)
         set_mtimecmp =   sym Clint::write_mtimecmp_naked,
-        options(noreturn)
     )
 }
 
@@ -90,9 +88,9 @@ unsafe extern "C" fn mtimer() {
 /// # Safety
 ///
 /// 裸函数。
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn msoft() {
-    asm!(
+    naked_asm!(
         // 换栈：
         // sp      : M sp
         // mscratch: S sp
@@ -125,6 +123,5 @@ unsafe extern "C" fn msoft() {
         clint_ptr  = sym CLINT,
         //               Clint::clear_msip_naked(&self, hart_idx)
         clear_msip = sym Clint::clear_msip_naked,
-        options(noreturn)
     )
 }

--- a/test-kernel/src/main.rs
+++ b/test-kernel/src/main.rs
@@ -1,12 +1,11 @@
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_const)]
 #![deny(warnings)]
 
 #[macro_use]
 extern crate rcore_console;
 
-use core::{arch::asm, ptr::null};
+use core::{arch::{asm, naked_asm}, ptr::null};
 use sbi_testing::sbi;
 use uart16550::Uart16550;
 
@@ -15,7 +14,7 @@ use uart16550::Uart16550;
 /// # Safety
 ///
 /// 裸函数。
-#[naked]
+#[unsafe(naked)]
 #[no_mangle]
 #[link_section = ".text.entry"]
 unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
@@ -24,13 +23,12 @@ unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
     #[link_section = ".bss.uninit"]
     static mut STACK: [u8; STACK_SIZE] = [0u8; STACK_SIZE];
 
-    asm!(
+    naked_asm!(
         "la sp, {stack} + {stack_size}",
         "j  {main}",
         stack_size = const STACK_SIZE,
         stack      =   sym STACK,
         main       =   sym rust_main,
-        options(noreturn),
     )
 }
 
@@ -170,11 +168,17 @@ impl Uart16550Map {
 impl rcore_console::Console for Console {
     #[inline]
     fn put_char(&self, c: u8) {
-        unsafe { UART.get().write(core::slice::from_ref(&c)) };
+        unsafe {
+            let mut_ref_uart = (*(&raw mut UART)).get();
+            mut_ref_uart.write(core::slice::from_ref(&c))
+        };
     }
 
     #[inline]
     fn put_str(&self, s: &str) {
-        unsafe { UART.get().write(s.as_bytes()) };
+        unsafe {
+            let mut_ref_uart = (*(&raw mut UART)).get();
+            mut_ref_uart.write(s.as_bytes())
+        };
     }
 }


### PR DESCRIPTION
After [https://github.com/rust-lang/rust/pull/128651](https://github.com/rust-lang/rust/pull/128651) merged in nightly toolchain, `asm!` macro is not allowed in naked functions.

Also, I discovered unhandled lint error including `creating a mutable reference to mutable static` and `creating a shared reference to mutable static`, which is making the program completely not runnable.

What's more, I discovered more `asm!`s in other dependencies, I upgraded version but nothing helped.

Therefore, this pull request aims to update rustsbi-qemu to adapt to current rust versions.

I also forked and made some changes in other dependency repositories, you need to accept them and update their versions in `cargo.toml` in order to successfully run the project.

**Changes**:

- Bump fast-trap version to 0.1.0
- Bump aclint version to 0.1.0
- Reorder date for CHANGELOG.md
- Replace #[naked] with #[unsafe(naked)] across all relevant functions.
- Remove `#![feature(naked_functions, asm_const)]` as they are no longer needed.
- Switche to the `naked_asm!` macro to comply with new naked function requirements.
- Remove `options(noreturn)`, which is not allowed in `naked_asm!`.
- Fix warning `creating a mutable/shared reference to mutable static` in multiple files.