### PR TITLE
fix: use valid ptr instead of its value

### DIFF
--- a/rustsbi-qemu/src/main.rs
+++ b/rustsbi-qemu/src/main.rs
@@ -72,8 +72,8 @@ extern "C" fn rust_main(hartid: usize, opaque: usize) {
             static mut ebss: u64;
         }
         unsafe {
-            let mut ptr = sbss as *mut u64;
-            let end = ebss as *mut u64;
+            let mut ptr = &raw mut sbss;
+            let end = &raw mut ebss;
             while ptr < end {
                 ptr.write_volatile(0);
                 ptr = ptr.offset(1);


### PR DESCRIPTION
the `ptr` and the `end` is not the addr of `sbss` and `ebss`, but its value

so previous code is actually accessing an invalid addr(probably 0)

cc @woshiluo, thx